### PR TITLE
two Korean teams moved their ball parks

### DIFF
--- a/ballparks.geojson
+++ b/ballparks.geojson
@@ -2643,9 +2643,9 @@
       "Class": "Other",
       "League": "Korea Baseball Championship",
       "Team": "Nexen Heroes",
-      "Ballpark": "Mokdong Baseball Stadium",
-      "Lat": "37.530706",
-      "Long": "126.880978"
+      "Ballpark": "Gocheok Sky Dome",
+      "Lat": "37.498400",
+      "Long": "126.867189"
     }
   }, {
     "type": "Feature",
@@ -2657,9 +2657,9 @@
       "Class": "Other",
       "League": "Korea Baseball Championship",
       "Team": "Samsung Lions",
-      "Ballpark": "Daegu Baseball Stadium",
-      "Lat": "35.880975",
-      "Long": "128.586572"
+      "Ballpark": "Daegu Samsung Lions Park",
+      "Lat": "35.840833",
+      "Long": "128.680833"
     }
   }, {
     "type": "Feature",

--- a/ballparks.geojson
+++ b/ballparks.geojson
@@ -2637,7 +2637,7 @@
     "type": "Feature",
     "geometry": {
       "type": "Point",
-      "coordinates": [126.880978, 37.530706]
+      "coordinates": [126.867189, 37.498400]
     },
     "properties": {
       "Class": "Other",
@@ -2658,8 +2658,8 @@
       "League": "Korea Baseball Championship",
       "Team": "Samsung Lions",
       "Ballpark": "Daegu Samsung Lions Park",
-      "Lat": "35.840833",
-      "Long": "128.680833"
+      "Lat": "35.880975",
+      "Long": "128.586572"
     }
   }, {
     "type": "Feature",

--- a/ballparks.geojson
+++ b/ballparks.geojson
@@ -2651,15 +2651,15 @@
     "type": "Feature",
     "geometry": {
       "type": "Point",
-      "coordinates": [128.586572, 35.880975]
+      "coordinates": [128.680833, 35.840833]
     },
     "properties": {
       "Class": "Other",
       "League": "Korea Baseball Championship",
       "Team": "Samsung Lions",
       "Ballpark": "Daegu Samsung Lions Park",
-      "Lat": "35.880975",
-      "Long": "128.586572"
+      "Lat": "35.840833",
+      "Long": "128.680833"
     }
   }, {
     "type": "Feature",


### PR DESCRIPTION
Two Korean teams moved their ball parks into newly built ones.
- Nexen Heroes to Gocheok Sky Dome from Mokdong Baseball Stadium
- Samsung Lions to Daegu Samsung Lions Park from Daegu Baseball Stadium

ref: https://en.wikipedia.org/wiki/KBO_League#Ballparks