### PR TITLE
Update Ballpark Name from SBC Park to AT&T Park

### DIFF
--- a/ballparks.geojson
+++ b/ballparks.geojson
@@ -333,7 +333,7 @@
       "Class": "Majors",
       "League": "Major League Baseball",
       "Team": "San Francisco Giants",
-      "Ballpark": "SBC Park",
+      "Ballpark": "AT&T Park",
       "Lat": "37.778473",
       "Long": "-122.389595"
     }


### PR DESCRIPTION
SBC Park was renamed to AT&T Park in 2006.