### PR TITLE
Update Ballpark Name from AT&T Park to Oracle Park

### DIFF
--- a/ballparks.geojson
+++ b/ballparks.geojson
@@ -333,7 +333,7 @@
       "Class": "Majors",
       "League": "Major League Baseball",
       "Team": "San Francisco Giants",
-      "Ballpark": "AT&T Park",
+      "Ballpark": "Oracle Park",
       "Lat": "37.778473",
       "Long": "-122.389595"
     }


### PR DESCRIPTION
AT&T Park was renamed to [Oracle Park](https://en.wikipedia.org/wiki/Oracle_Park) in 2019



[I feel like I am in an episode of the Twilight Zone](https://github.com/cageyjames/GeoJSON-Ballparks/pull/23). 😆 